### PR TITLE
Add export_keying_material and get_server_random

### DIFF
--- a/_sslkeylog.c
+++ b/_sslkeylog.c
@@ -171,7 +171,7 @@ static PyObject *sslkeylog_export_keying_material(PyObject *m, PyObject *args)
     Py_buffer context = {0};
     PyObject *result = NULL;
 
-    if (!PyArg_ParseTuple(args, "O!ns#|y*:export_keying_material", sslsocket_type, &sslsocket,
+    if (!PyArg_ParseTuple(args, "O!ns#|z*:export_keying_material", sslsocket_type, &sslsocket,
                           &out_length, &label, &label_length, &context)) {
         return NULL;
     }

--- a/_sslkeylog.c
+++ b/_sslkeylog.c
@@ -1,3 +1,4 @@
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <openssl/ssl.h>
 
@@ -57,6 +58,16 @@ static size_t SSL_get_client_random(const SSL *ssl, unsigned char *out, size_t o
     return outlen;
 }
 
+size_t SSL_get_server_random(const SSL *ssl, unsigned char *out, size_t outlen)
+{
+    if (outlen == 0)
+        return sizeof(ssl->s3.server_random);
+    if (outlen > sizeof(ssl->s3.server_random))
+        outlen = sizeof(ssl->s3.server_random);
+    memcpy(out, ssl->s3.server_random, outlen);
+    return outlen;
+}
+
 static size_t SSL_SESSION_get_master_key(const SSL_SESSION *session,
                                          unsigned char *out, size_t outlen)
 {
@@ -94,6 +105,31 @@ static PyObject *sslkeylog_get_client_random(PyObject *m, PyObject *args)
     return result;
 }
 
+static PyObject *sslkeylog_get_server_random(PyObject *m, PyObject *args)
+{
+    PySSLSocket *sslsocket;
+    size_t size;
+    PyObject *result;
+
+    if (!PyArg_ParseTuple(args, "O!:get_server_random", sslsocket_type, &sslsocket)) {
+        return NULL;
+    }
+
+    if (!sslsocket->ssl) {
+        Py_RETURN_NONE;
+    }
+
+    size = SSL_get_server_random(sslsocket->ssl, NULL, 0);
+    result = PyBytes_FromStringAndSize(NULL, size);
+    if (!result) {
+        return NULL;
+    }
+
+    SSL_get_server_random(sslsocket->ssl, (unsigned char *)PyBytes_AS_STRING(result), size);
+
+    return result;
+}
+
 static PyObject *sslkeylog_get_master_key(PyObject *m, PyObject *args)
 {
     PySSLSocket *sslsocket;
@@ -124,6 +160,48 @@ static PyObject *sslkeylog_get_master_key(PyObject *m, PyObject *args)
 
     return result;
 }
+
+#if OPENSSL_VERSION_NUMBER >= 0x10001000L
+static PyObject *sslkeylog_export_keying_material(PyObject *m, PyObject *args)
+{
+    PySSLSocket *sslsocket;
+    Py_ssize_t out_length;
+    const char *label;
+    Py_ssize_t label_length;
+    Py_buffer context = {0};
+    PyObject *result = NULL;
+
+    if (!PyArg_ParseTuple(args, "O!ns#|y*:export_keying_material", sslsocket_type, &sslsocket,
+                          &out_length, &label, &label_length, &context)) {
+        return NULL;
+    }
+
+    if (!sslsocket->ssl) {
+        Py_RETURN_NONE;
+    }
+
+    result = PyBytes_FromStringAndSize(NULL, out_length);
+    if (!result) {
+        goto out;
+    }
+
+    if (SSL_export_keying_material(
+        sslsocket->ssl,
+        (unsigned char *)PyBytes_AS_STRING(result),
+        (size_t)out_length,
+        label, (size_t)label_length,
+        context.buf, context.len, context.buf != NULL) != 1) {
+            Py_CLEAR(result);
+            PyErr_SetString(PyExc_RuntimeError, "SSL_export_keying_material() failed");
+            goto out;
+    }
+
+out:
+    PyBuffer_Release(&context);
+
+    return result;
+}
+#endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
 typedef struct {
@@ -206,8 +284,14 @@ static PyObject *sslkeylog_set_keylog_callback(PyObject *m, PyObject *args)
 static PyMethodDef sslkeylogmethods[] = {
     {"get_client_random", sslkeylog_get_client_random, METH_VARARGS,
      NULL},
+    {"get_server_random", sslkeylog_get_server_random, METH_VARARGS,
+     NULL},
     {"get_master_key", sslkeylog_get_master_key, METH_VARARGS,
      NULL},
+#if OPENSSL_VERSION_NUMBER >= 0x10001000L
+    {"export_keying_material", sslkeylog_export_keying_material, METH_VARARGS,
+     NULL},
+#endif
 #if OPENSSL_VERSION_NUMBER >= 0x10101000L
     {"set_keylog_callback", sslkeylog_set_keylog_callback, METH_VARARGS,
      NULL},
@@ -273,6 +357,7 @@ PyMODINIT_FUNC init_sslkeylog(void)
             sslkeylog_ex_data_free);
         if (sslkeylog_ex_data_index == -1) {
             Py_CLEAR(m);
+            PyErr_SetString(PyExc_RuntimeError, "SSL_CTX_get_ex_new_index() failed");
             goto out;
         }
     }

--- a/sslkeylog.py
+++ b/sslkeylog.py
@@ -56,6 +56,25 @@ def get_client_random(sock):
     return _sslkeylog.get_client_random(sock)
 
 
+def get_server_random(sock):
+    """
+    Get the server random from an :class:`ssl.SSLSocket` or :class:`ssl.SSLObject`.
+
+    .. note:: Does not work with TLS v1.3+ sockets.
+    """
+    if sock is None:
+        raise TypeError(
+            "get_server_random() argument must be ssl.SSLSocket or ssl.SSLObject, not None")
+
+    # Some Python versions implement SSLSocket using SSLObject so we need to dereference twice
+    sock = getattr(sock, '_sslobj', sock)
+    sock = getattr(sock, '_sslobj', sock)
+    if sock is None:
+        return None
+
+    return _sslkeylog.get_server_random(sock)
+
+
 def get_master_key(sock):
     """
     Get the master key from an :class:`ssl.SSLSocket` or :class:`ssl.SSLObject`.
@@ -73,6 +92,29 @@ def get_master_key(sock):
         return None
 
     return _sslkeylog.get_master_key(sock)
+
+
+def export_keying_material(sock, length, label, context=None):
+    """
+    Obtain keying material for application use from an :class:`ssl.SSLSocket` or
+    :class:`ssl.SSLObject`.
+
+    .. note:: Does not work with SSL v3.0 or below sockets.
+    """
+    if ssl.OPENSSL_VERSION_INFO[:3] < (1, 0, 1):
+        raise NotImplementedError("Method not implemented in OpenSSL older than 1.0.1")
+
+    if sock is None:
+        raise TypeError(
+            "export_keying_material() argument must be ssl.SSLSocket or ssl.SSLObject, not None")
+
+    # Some Python versions implement SSLSocket using SSLObject so we need to dereference twice
+    sock = getattr(sock, '_sslobj', sock)
+    sock = getattr(sock, '_sslobj', sock)
+    if sock is None:
+        return None
+
+    return _sslkeylog.export_keying_material(sock, length, label, context)
 
 
 def get_keylog_line(sock):

--- a/tests/test_sslkeylog.py
+++ b/tests/test_sslkeylog.py
@@ -116,6 +116,20 @@ def test_get_client_random_not_a_socket():
         sslkeylog.get_client_random(object())
 
 
+def test_get_server_random(ssl_client12):
+    assert sslkeylog.get_server_random(ssl_client12)
+
+
+def test_get_server_random_none():
+    with pytest.raises(TypeError):
+        sslkeylog.get_server_random(None)
+
+
+def test_get_server_random_not_a_socket():
+    with pytest.raises(TypeError):
+        sslkeylog.get_server_random(object())
+
+
 def test_get_master_key(ssl_client12):
     assert sslkeylog.get_master_key(ssl_client12)
 
@@ -128,6 +142,24 @@ def test_get_master_key_none():
 def test_get_master_key_not_a_socket():
     with pytest.raises(TypeError):
         sslkeylog.get_master_key(object())
+
+
+def test_export_keying_material(ssl_client12):
+    assert sslkeylog.export_keying_material(ssl_client12, 32, "EXPERIMENTAL-test")
+
+
+def test_export_keying_material_with_context(ssl_client12):
+    assert sslkeylog.export_keying_material(ssl_client12, 32, "EXPERIMENTAL-test", b"test")
+
+
+def test_export_keying_material_none():
+    with pytest.raises(TypeError):
+        sslkeylog.export_keying_material(None, 32, "EXPERIMENTAL-test")
+
+
+def test_export_keying_material_not_a_socket():
+    with pytest.raises(TypeError):
+        sslkeylog.export_keying_material(object(), 32, "EXPERIMENTAL-test")
 
 
 def test_get_keylog_line(ssl_client12):


### PR DESCRIPTION
Cleanup of #4. @alex-eri might want to check that this works for your use case.

### TODO
- [x] Write tests
- [x] Check that it builds and tests pass with all supported Python + OpenSSL combination. (Need to setup CI at some point, but it's not trivial), Can't do Windows Python 2.7 anymore as Microsoft just nuked the compilers for it from existence.
- [ ] Consider if we also want `SSL_export_keying_material_early` for OpenSSL 1.1.1+  &ndash; https://github.com/segevfiner/sslkeylog/issues/10