### PR TITLE
Fix macos/sonoma build

### DIFF
--- a/_sslkeylog.c
+++ b/_sslkeylog.c
@@ -233,7 +233,7 @@ static void sslkeylog_ex_data_new(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
 }
 
 static int sslkeylog_ex_data_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
-                                 void *from_d, int idx, long argl, void *argp)
+                                 void **from_d, int idx, long argl, void *argp)
 {
     return 0;
 }


### PR DESCRIPTION
Build is failing on mac/sonoma due to a typo in `sslkeylog_ex_data_dup` (incompatible function pointer types)